### PR TITLE
Allow overriding block templates through block arguments

### DIFF
--- a/lib/internal/Magento/Framework/View/Layout/Generator/Block.php
+++ b/lib/internal/Magento/Framework/View/Layout/Generator/Block.php
@@ -225,7 +225,7 @@ class Block implements Layout\GeneratorInterface
         $block = $this->createBlock($className, $elementName, [
             'data' => $this->evaluateArguments($data['arguments'])
         ]);
-        if (!empty($attributes['template'])) {
+        if (!$block->hasTemplate() && !empty($attributes['template'])) {
             $block->setTemplate($attributes['template']);
         }
         if (!empty($attributes['ttl'])) {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Without checking if the template is set already, this causes the template attribute to always override any arguments set, preventing you from changing the template without using the deprecated action node. This PR makes the simple change of checking if the template is already set before attempting to overwrite it with the attribute template.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#3356: XML syntax to change block's template

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Use a reference block node for a block that defines a template as an attribute (such as checkout.customer.sku in Magento_AdvancedCheckout) and define the template as an argument:
```xml
<referenceBlock name="checkout.customer.sku">
    <arguments>
        <argument name="template" xsi:type="string">MyCompany_MyModule::widget/sku.phtml</argument>
    </arguments>
</referenceBlock>
```

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
